### PR TITLE
Add CustomTkinter UI scaffolding

### DIFF
--- a/project/ui/__init__.py
+++ b/project/ui/__init__.py
@@ -1,0 +1,1 @@
+"""User interface package."""

--- a/project/ui/app.py
+++ b/project/ui/app.py
@@ -1,0 +1,77 @@
+"""Main application window with navigation."""
+
+import customtkinter as ctk
+
+from .dashboard_frame import DashboardFrame
+from .generator_frame import GeneratorFrame
+
+
+class App(ctk.CTk):
+    """Application root class."""
+
+    def __init__(self):
+        super().__init__()
+        self.title("Générateur de séances")
+        self.geometry("900x600")
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(1, weight=1)
+
+        self._create_sidebar()
+        self._create_container()
+        self._create_frames()
+        self.show_frame("dashboard")
+
+    def _create_sidebar(self):
+        self.sidebar = ctk.CTkFrame(self, width=180)
+        self.sidebar.grid(row=0, column=0, sticky="ns")
+        self.sidebar.grid_rowconfigure(5, weight=1)
+
+        ctk.CTkButton(
+            self.sidebar, text="Accueil", command=lambda: self.show_frame("dashboard")
+        ).grid(row=0, column=0, padx=20, pady=10, sticky="ew")
+        ctk.CTkButton(
+            self.sidebar, text="Générateur", command=lambda: self.show_frame("generator")
+        ).grid(row=1, column=0, padx=20, pady=10, sticky="ew")
+        ctk.CTkButton(
+            self.sidebar, text="Séances", command=lambda: self.show_frame("sessions")
+        ).grid(row=2, column=0, padx=20, pady=10, sticky="ew")
+        ctk.CTkButton(
+            self.sidebar, text="Exercices", command=lambda: self.show_frame("exercises")
+        ).grid(row=3, column=0, padx=20, pady=10, sticky="ew")
+        ctk.CTkButton(
+            self.sidebar, text="Paramètres", command=lambda: self.show_frame("settings")
+        ).grid(row=4, column=0, padx=20, pady=10, sticky="ew")
+
+    def _create_container(self):
+        self.container = ctk.CTkFrame(self)
+        self.container.grid(row=0, column=1, sticky="nsew")
+        self.container.grid_rowconfigure(0, weight=1)
+        self.container.grid_columnconfigure(0, weight=1)
+
+    def _create_frames(self):
+        self.frames = {
+            "dashboard": DashboardFrame(self.container),
+            "generator": GeneratorFrame(self.container),
+            "sessions": self._placeholder("Séances"),
+            "exercises": self._placeholder("Exercices"),
+            "settings": self._placeholder("Paramètres"),
+        }
+        for frame in self.frames.values():
+            frame.grid(row=0, column=0, sticky="nsew")
+
+    def _placeholder(self, name):
+        frame = ctk.CTkFrame(self.container)
+        ctk.CTkLabel(
+            frame, text=f"Module '{name}' en cours de développement..."
+        ).grid(padx=20, pady=20)
+        return frame
+
+    def show_frame(self, key):
+        frame = self.frames.get(key)
+        if frame:
+            frame.tkraise()
+
+
+if __name__ == "__main__":
+    app = App()
+    app.mainloop()

--- a/project/ui/dashboard_frame.py
+++ b/project/ui/dashboard_frame.py
@@ -1,0 +1,29 @@
+"""Dashboard frame displaying KPIs and quick actions."""
+
+import customtkinter as ctk
+
+
+class DashboardFrame(ctk.CTkFrame):
+    """Home dashboard for the application."""
+
+    def __init__(self, master, **kwargs):
+        super().__init__(master, **kwargs)
+        self.grid_rowconfigure((0, 1), weight=1)
+        self.grid_columnconfigure((0, 1), weight=1)
+
+        # KPI tiles
+        kpi1 = ctk.CTkFrame(self)
+        kpi1.grid(row=0, column=0, padx=20, pady=20, sticky="nsew")
+        ctk.CTkLabel(kpi1, text="Séances générées\n12", justify="center").pack(expand=True)
+
+        kpi2 = ctk.CTkFrame(self)
+        kpi2.grid(row=0, column=1, padx=20, pady=20, sticky="nsew")
+        ctk.CTkLabel(kpi2, text="Clients actifs\n5", justify="center").pack(expand=True)
+
+        # Quick actions
+        actions = ctk.CTkFrame(self)
+        actions.grid(row=1, column=0, columnspan=2, padx=20, pady=(0, 20), sticky="nsew")
+        actions.grid_columnconfigure((0, 1), weight=1)
+
+        ctk.CTkButton(actions, text="Nouvelle séance").grid(row=0, column=0, padx=20, pady=20, sticky="ew")
+        ctk.CTkButton(actions, text="Importer séance").grid(row=0, column=1, padx=20, pady=20, sticky="ew")

--- a/project/ui/generator_frame.py
+++ b/project/ui/generator_frame.py
@@ -1,0 +1,99 @@
+"""Session generator UI frame."""
+
+import customtkinter as ctk
+
+from .preview_frame import PreviewFrame
+
+
+class GeneratorFrame(ctk.CTkFrame):
+    """Frame containing the session generator form and preview."""
+
+    def __init__(self, master, **kwargs):
+        super().__init__(master, **kwargs)
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_columnconfigure(1, weight=1)
+
+        self._build_form()
+        self._build_preview()
+
+    def _build_form(self):
+        form = ctk.CTkScrollableFrame(self, width=300)
+        form.grid(row=0, column=0, sticky="nsew", padx=20, pady=20)
+        form.grid_columnconfigure(0, weight=1)
+        row = 0
+
+        name_label = ctk.CTkLabel(form, text="Nom de la séance")
+        name_label.grid(row=row, column=0, sticky="w")
+        row += 1
+        ctk.CTkEntry(form).grid(row=row, column=0, sticky="ew", pady=(0, 10))
+        row += 1
+
+        duration_label = ctk.CTkLabel(form, text="Durée (min)")
+        duration_label.grid(row=row, column=0, sticky="w")
+        row += 1
+        duration = ctk.CTkOptionMenu(form, values=["30", "45", "60", "90"])
+        duration.set("45")
+        duration.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+        row += 1
+
+        type_label = ctk.CTkLabel(form, text="Type de séance")
+        type_label.grid(row=row, column=0, sticky="w")
+        row += 1
+        type_menu = ctk.CTkOptionMenu(form, values=["HIIT", "Force", "Endurance", "Mobilité"])
+        type_menu.set("HIIT")
+        type_menu.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+        row += 1
+
+        obj_label = ctk.CTkLabel(form, text="Objectif")
+        obj_label.grid(row=row, column=0, sticky="w")
+        row += 1
+        obj_menu = ctk.CTkOptionMenu(form, values=["Force", "Endurance", "Mobilité"])
+        obj_menu.set("Endurance")
+        obj_menu.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+        row += 1
+
+        equip_label = ctk.CTkLabel(form, text="Matériel", font=ctk.CTkFont(weight="bold"))
+        equip_label.grid(row=row, column=0, sticky="w")
+        row += 1
+        ctk.CTkCheckBox(form, text="Poids de corps").grid(row=row, column=0, sticky="w")
+        row += 1
+        ctk.CTkCheckBox(form, text="Haltères").grid(row=row, column=0, sticky="w")
+        row += 1
+        ctk.CTkCheckBox(form, text="Kettlebells").grid(row=row, column=0, sticky="w")
+        row += 1
+        ctk.CTkCheckBox(form, text="TRX").grid(row=row, column=0, sticky="w", pady=(0, 10))
+        row += 1
+
+        var_label = ctk.CTkLabel(form, text="Variabilité")
+        var_label.grid(row=row, column=0, sticky="w")
+        row += 1
+        var_slider = ctk.CTkSlider(form, from_=0, to=100, number_of_steps=100)
+        var_slider.set(50)
+        var_slider.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+        row += 1
+
+        vol_label = ctk.CTkLabel(form, text="Volume")
+        vol_label.grid(row=row, column=0, sticky="w")
+        row += 1
+        vol_slider = ctk.CTkSlider(form, from_=0.5, to=2.0)
+        vol_slider.set(1.0)
+        vol_slider.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+        row += 1
+
+        int_label = ctk.CTkLabel(form, text="Biais intensité")
+        int_label.grid(row=row, column=0, sticky="w")
+        row += 1
+        int_slider = ctk.CTkSlider(form, from_=0, to=100)
+        int_slider.set(50)
+        int_slider.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+        row += 1
+
+        ctk.CTkButton(form, text="Générer", state="disabled").grid(
+            row=row, column=0, sticky="ew", pady=20
+        )
+
+    def _build_preview(self):
+        preview = PreviewFrame(self)
+        preview.grid(row=0, column=1, sticky="nsew", padx=20, pady=20)
+        self.preview = preview

--- a/project/ui/mock_data.py
+++ b/project/ui/mock_data.py
@@ -1,0 +1,29 @@
+"""Mock data for UI testing."""
+
+
+def get_mock_session():
+    """Return a mock training session for preview purposes."""
+    return {
+        "name": "Séance Full-body mock",
+        "duration": 45,
+        "objective": "Endurance",
+        "blocks": [
+            {
+                "type": "Warmup",
+                "exercises": [
+                    {"name": "Jumping Jacks", "details": "3 min"},
+                    {"name": "Squat Poids de corps", "details": "15 reps"},
+                ],
+            },
+            {
+                "type": "Circuit",
+                "exercises": [
+                    {"name": "Kettlebell Swing", "details": "15 reps"},
+                    {"name": "Push Up", "details": "10 reps"},
+                    {"name": "Inverted Row", "details": "10 reps"},
+                    {"name": "Plank", "details": "30 sec"},
+                ],
+                "details": "3 tours",
+            },
+        ],
+    }

--- a/project/ui/preview_frame.py
+++ b/project/ui/preview_frame.py
@@ -1,0 +1,61 @@
+"""Preview frame for displaying generated sessions."""
+
+import customtkinter as ctk
+from .mock_data import get_mock_session
+
+
+class PreviewFrame(ctk.CTkFrame):
+    """Frame used to render a session preview."""
+
+    def __init__(self, master, **kwargs):
+        super().__init__(master, **kwargs)
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+        self._content = ctk.CTkFrame(self)
+        self._content.grid(row=0, column=0, sticky="nsew", padx=10, pady=10)
+        self._content.grid_columnconfigure(0, weight=1)
+        self.render_session()
+
+    def render_session(self, session_data=None):
+        """Render the given session data. Uses mock data by default."""
+        if session_data is None:
+            session_data = get_mock_session()
+
+        for widget in self._content.winfo_children():
+            widget.destroy()
+
+        row = 0
+        title = ctk.CTkLabel(
+            self._content,
+            text=session_data.get("name", "Séance"),
+            font=ctk.CTkFont(size=16, weight="bold"),
+        )
+        title.grid(row=row, column=0, sticky="w")
+        row += 1
+
+        info = ctk.CTkLabel(
+            self._content,
+            text=f"Durée : {session_data.get('duration', '?')} min | Objectif : {session_data.get('objective', '')}",
+        )
+        info.grid(row=row, column=0, sticky="w", pady=(0, 10))
+        row += 1
+
+        for block in session_data.get("blocks", []):
+            block_lbl = ctk.CTkLabel(
+                self._content,
+                text=block.get("type", "Bloc"),
+                font=ctk.CTkFont(weight="bold"),
+            )
+            block_lbl.grid(row=row, column=0, sticky="w")
+            row += 1
+            for ex in block.get("exercises", []):
+                ex_lbl = ctk.CTkLabel(
+                    self._content,
+                    text=f"• {ex.get('name', '')} - {ex.get('details', '')}",
+                )
+                ex_lbl.grid(row=row, column=0, sticky="w", padx=10)
+                row += 1
+            if block.get("details"):
+                details_lbl = ctk.CTkLabel(self._content, text=block["details"])
+                details_lbl.grid(row=row, column=0, sticky="w", padx=10)
+                row += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 peewee
 PyYAML
+customtkinter


### PR DESCRIPTION
## Summary
- scaffold basic CustomTkinter interface with sidebar navigation
- add generator dashboard and preview frames using mock session data
- include CustomTkinter in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68b19df3f7f8832aa79322df57d65a39