### PR TITLE
feat(ui): introduce reusable cards

### DIFF
--- a/project/core/generator.py
+++ b/project/core/generator.py
@@ -89,7 +89,6 @@ def _assign_reps_or_time(objective: str) -> str:
 
 def generate_session(params: Dict) -> models.Session:
     params = _merge_params(params)
-    random.seed(None)
     if params["variability"] == 0:
         random.seed(0)
 
@@ -113,7 +112,8 @@ def generate_session(params: Dict) -> models.Session:
         if not candidates:
             raise GenerationError(f"No exercise for pattern {pattern}")
         scored = sorted(candidates, key=lambda e: _score_exercise(e, params), reverse=True)
-        exercise = scored[0]
+        top_n = max(1, round(len(scored) * params["variability"] / 100))
+        exercise = random.choice(scored[:top_n])
         used_ids.add(exercise.id)
         block = models.Block(block_type="Core", order=i, duration=600)
         eb = models.ExerciseBlock(block=block, exercise=exercise, order=0,

--- a/project/ui/components/card.py
+++ b/project/ui/components/card.py
@@ -1,0 +1,42 @@
+import customtkinter as ctk
+
+
+class Card(ctk.CTkFrame):
+    """Generic card widget used as a container for displaying information.
+
+    Parameters
+    ----------
+    master : widget
+        Parent widget.
+    title : str
+        Title displayed at the top of the card.
+    value : str
+        Main value or highlight shown below the title.
+    description : str
+        Descriptive text placed under the value.
+    **kwargs : Any
+        Additional arguments forwarded to :class:`CTkFrame`.
+    """
+
+    def __init__(self, master, title="", value="", description="", **kwargs):
+        super().__init__(master, corner_radius=8, fg_color=("gray85", "gray20"), **kwargs)
+
+        self.grid_columnconfigure(0, weight=1)
+        # Title
+        self.title_label = ctk.CTkLabel(self, text=title)
+        self.title_label.grid(row=0, column=0, sticky="w", padx=10, pady=(10, 0))
+
+        # Main value
+        self.value_label = ctk.CTkLabel(
+            self, text=value, font=ctk.CTkFont(size=20, weight="bold")
+        )
+        self.value_label.grid(row=1, column=0, sticky="w", padx=10)
+
+        # Description
+        self.description_label = ctk.CTkLabel(self, text=description)
+        self.description_label.grid(row=2, column=0, sticky="w", padx=10, pady=(0, 10))
+
+        # Container frame for additional widgets
+        self.content = ctk.CTkFrame(self, fg_color="transparent")
+        self.content.grid(row=3, column=0, sticky="nsew", padx=10, pady=(0, 10))
+        self.grid_rowconfigure(3, weight=1)

--- a/project/ui/components/exercise_card.py
+++ b/project/ui/components/exercise_card.py
@@ -1,0 +1,8 @@
+from .card import Card
+
+
+class ExerciseCard(Card):
+    """Card specialized for displaying exercise information."""
+
+    def __init__(self, master, name: str, details: str = "", **kwargs):
+        super().__init__(master, title=name, description=details, **kwargs)

--- a/project/ui/dashboard_frame.py
+++ b/project/ui/dashboard_frame.py
@@ -2,6 +2,8 @@
 
 import customtkinter as ctk
 
+from .components.card import Card
+
 
 class DashboardFrame(ctk.CTkFrame):
     """Home dashboard for the application."""
@@ -11,14 +13,22 @@ class DashboardFrame(ctk.CTkFrame):
         self.grid_rowconfigure((0, 1), weight=1)
         self.grid_columnconfigure((0, 1), weight=1)
 
-        # KPI tiles
-        kpi1 = ctk.CTkFrame(self)
+        # KPI cards
+        kpi1 = Card(
+            self,
+            title="Séances générées",
+            value="12",
+            description="dans la base",
+        )
         kpi1.grid(row=0, column=0, padx=20, pady=20, sticky="nsew")
-        ctk.CTkLabel(kpi1, text="Séances générées\n12", justify="center").pack(expand=True)
 
-        kpi2 = ctk.CTkFrame(self)
+        kpi2 = Card(
+            self,
+            title="Exercices dans la base",
+            value="5",
+            description="actifs",
+        )
         kpi2.grid(row=0, column=1, padx=20, pady=20, sticky="nsew")
-        ctk.CTkLabel(kpi2, text="Clients actifs\n5", justify="center").pack(expand=True)
 
         # Quick actions
         actions = ctk.CTkFrame(self)

--- a/project/ui/mock_data.py
+++ b/project/ui/mock_data.py
@@ -10,6 +10,7 @@ def get_mock_session():
         "blocks": [
             {
                 "type": "Warmup",
+                "duration": 10,
                 "exercises": [
                     {"name": "Jumping Jacks", "details": "3 min"},
                     {"name": "Squat Poids de corps", "details": "15 reps"},
@@ -17,6 +18,7 @@ def get_mock_session():
             },
             {
                 "type": "Circuit",
+                "duration": 35,
                 "exercises": [
                     {"name": "Kettlebell Swing", "details": "15 reps"},
                     {"name": "Push Up", "details": "10 reps"},

--- a/project/ui/preview_frame.py
+++ b/project/ui/preview_frame.py
@@ -2,6 +2,8 @@
 
 import customtkinter as ctk
 from .mock_data import get_mock_session
+from .components.card import Card
+from .components.exercise_card import ExerciseCard
 
 
 class PreviewFrame(ctk.CTkFrame):
@@ -41,21 +43,23 @@ class PreviewFrame(ctk.CTkFrame):
         row += 1
 
         for block in session_data.get("blocks", []):
-            block_lbl = ctk.CTkLabel(
+            card = Card(
                 self._content,
-                text=block.get("type", "Bloc"),
-                font=ctk.CTkFont(weight="bold"),
+                title=block.get("type", "Bloc"),
+                value=f"{block.get('duration', '?')} min",
+                description=block.get("details", ""),
             )
-            block_lbl.grid(row=row, column=0, sticky="w")
-            row += 1
+            card.grid(row=row, column=0, sticky="nsew", pady=(0, 10))
+            card.grid_columnconfigure(0, weight=1)
+
+            ex_row = 0
             for ex in block.get("exercises", []):
-                ex_lbl = ctk.CTkLabel(
-                    self._content,
-                    text=f"• {ex.get('name', '')} - {ex.get('details', '')}",
+                ex_card = ExerciseCard(
+                    card.content,
+                    name=ex.get("name", ""),
+                    details=ex.get("details", ""),
                 )
-                ex_lbl.grid(row=row, column=0, sticky="w", padx=10)
-                row += 1
-            if block.get("details"):
-                details_lbl = ctk.CTkLabel(self._content, text=block["details"])
-                details_lbl.grid(row=row, column=0, sticky="w", padx=10)
-                row += 1
+                ex_card.grid(row=ex_row, column=0, sticky="ew", pady=2)
+                ex_row += 1
+
+            row += 1


### PR DESCRIPTION
## Summary
- add generic `Card` widget and `ExerciseCard` derivative
- refactor dashboard and preview to display information with cards
- tweak generator to randomly pick among top-scoring exercises for variability

## Testing
- `pip install -r requirements.txt`
- `pytest project/tests/tests_core.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1ac97485c832aa8144ebd278bd881